### PR TITLE
Give option to skip SSL verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ func realMain() int {
 	caCert := flag.String("cacert", "", "TLS CACert file path")
 	cert := flag.String("cert", "", "TLS Cert file path")
 	key := flag.String("key", "", "TLS Key file path")
+	skipVerify := flag.Bool("skipverify", false, "Skip SSL Verification - DANGER - (Use to connect to Heroku Private Redis instances)")
+
 	flag.Parse()
 
 	if !isFlagPassed("db") {
@@ -72,7 +74,7 @@ func realMain() int {
 	var tlshandler *redisdump.TlsHandler
 	if isFlagPassed("tls") {
 		*tls = true
-		tlshandler = redisdump.NewTlsHandler(*tls, *caCert, *cert, *key)
+		tlshandler = redisdump.NewTlsHandler(*tls, *caCert, *cert, *key, *skipVerify)
 	}
 
 	var serializer func([]string) string

--- a/redisdump/tls_utils.go
+++ b/redisdump/tls_utils.go
@@ -12,18 +12,20 @@ import (
 )
 
 type TlsHandler struct {
-	tls        bool
-	caCertPath string
-	certPath   string
-	keyPath    string
+	tls                bool
+	caCertPath         string
+	certPath           string
+	keyPath            string
+	insecureSkipVerify bool
 }
 
-func NewTlsHandler(tls bool, caCertPath, certPath, keyPath string) *TlsHandler {
+func NewTlsHandler(tls bool, caCertPath string, certPath string, keyPath string, insecureSkipVerify bool) *TlsHandler {
 	return &TlsHandler{
-		tls:        tls,
-		caCertPath: caCertPath,
-		certPath:   certPath,
-		keyPath:    keyPath,
+		tls:                tls,
+		caCertPath:         caCertPath,
+		certPath:           certPath,
+		keyPath:            keyPath,
+		insecureSkipVerify: insecureSkipVerify,
 	}
 }
 
@@ -64,8 +66,9 @@ func createTlsConfig(tlsHandler *TlsHandler) (*tls.Config, error) {
 			}
 		}
 		tlsConfig = &tls.Config{
-			Certificates: []tls.Certificate{},
-			RootCAs:      certPool,
+			Certificates:       []tls.Certificate{},
+			RootCAs:            certPool,
+			InsecureSkipVerify: tlsHandler.insecureSkipVerify,
 		}
 		if tlsHandler.certPath != "" && tlsHandler.keyPath != "" {
 			cert, err := tls.LoadX509KeyPair(tlsHandler.certPath, tlsHandler.keyPath)


### PR DESCRIPTION
We are using this to migrate out of Heroku. However, we are using a Shielded space (high compliance Heroku environment). Heroku forces SSL connections to Redis but uses self-signed certificates.

See here: https://help.heroku.com/HC0F8CUS/redis-connection-issues

This PR simply adds an option to specify `InsecureSkipVerify: true` in the connection that radix establishes. Thus bypassing the hostname and cert authority issues with their certs.